### PR TITLE
Support for older git versions

### DIFF
--- a/add_important_files.sh
+++ b/add_important_files.sh
@@ -1,0 +1,26 @@
+HOWTO="Usage: $0 -o <path/to/activity/repo> file1, file2, ..."
+
+HELP="Copia los archivos file1, file2, ... en la base de los repos de todos los alumnos de una actividad. Se debe pasar el path a la carpeta de la actividad y el path a cada uno de los archivos que se debe copiar.\n\n$HOWTO"
+
+while getopts "o:h" optname; do
+    case $optname in
+        h) echo $HELP && exit 0;;
+        o) o=$OPTARG;;
+        ?) echo $HOWTO && exit 1;;   
+    esac
+done
+
+if [ -z "$o" ]; then
+    echo $HOWTO && exit 1;
+fi
+
+echo $o
+
+shift $((OPTIND-1))
+
+for file; do
+    for dir in $o/*/; do
+        cp $file $dir;
+        echo "Copied $file to $dir"
+    done
+done

--- a/repos_downloader.py
+++ b/repos_downloader.py
@@ -29,10 +29,12 @@ path_csv = args.path
 corrector = args.corrector
 # Subdirectorio a descargar: T3, AF6, AS2 ...
 actividad = args.actividad
+# Estudiante (si lo hay)
+estudiante = args.estudiante
 
 # URL absoluta al repositorio, no debería ser necesario cambiarla
-repo_base = r"https://github.com/IIC2233/"
-path_repo = repo_base + actividad
+repo_base = r"git@github.com:IIC2233/{}.git"
+path_repo = repo_base.format(actividad)
 
 
 def modo_automatico():
@@ -40,25 +42,33 @@ def modo_automatico():
     datos = parsear_datos_csv(path_csv)
 
     # Comando inicial, crea el repositorio respectivo vacío, para poder agregarle contenido
-    git_setup = "git clone --depth 1 --filter=blob:none --sparse " + path_repo
-    os.system(git_setup)
+    os.mkdir(actividad)
+    os.chdir(actividad)
+    os.system("git init")
+    os.system("git sparse-checkout init")
+    os.system(f"git remote add -f origin {path_repo}")
+
+    my_students = ""
 
     # Itera sobre los alumnos y correctores, para agregar a la carpeta sólo las subcarpetas
     for linea in datos:
         alumno, corr = (linea[0], linea[1])
         if corr == corrector:
-            os.system(f"cd {actividad} && git sparse-checkout add {alumno}")
+            my_students = f"{my_students} {alumno}"
+    os.system(f"git sparse-checkout set {my_students}")
+    os.system("git pull origin master")
 
 
-def modo_manual(actividad_especifica, alumno):
-    print(f"Descargando {actividad_especifica} de {alumno}!")
-    git_setup = (
-        "git clone --depth 1 --filter=blob:none --sparse "
-        + repo_base
-        + actividad_especifica
-    )
-    os.system(git_setup)
-    os.system(f"cd {actividad_especifica} && git sparse-checkout add {alumno}")
+def modo_manual():
+    print(f"Descargando {actividad} de {estudiante}!")
+    os.mkdir(actividad)
+    os.chdir(actividad)
+    os.system("git init")
+    os.system("git sparse-checkout init")
+    os.system(f"git remote add -f origin {path_repo}")
+    
+    os.system(f"git sparse-checkout set {estudiante}")
+    os.system("git pull origin master")
 
 
 def modo_forzado():
@@ -100,7 +110,7 @@ if __name__ == "__main__":
         print("Modo manual")
         # argumentos: actividad y alumno
         assert isinstance(args.estudiante, str)
-        modo_manual(args.actividad, args.estudiante)
+        modo_manual()
 
     elif re.search("[a]", args.modo, re.IGNORECASE):
         # toma las variables globales como parámetros, y descarga todos los elementos del CSV

--- a/repos_downloader.sh
+++ b/repos_downloader.sh
@@ -1,0 +1,44 @@
+HOWTO="Usage: $0 -a <actividad> -p <path/to/csv> -c <corrector>"
+
+
+while getopts "a:c:p:" optname; do
+    case $optname in
+        a) a=$OPTARG;;
+        c) c=$OPTARG;;
+        p) p=$OPTARG;;
+        ?) echo $HOWTO && exit 1;;   
+    esac
+done
+
+if [ -z "$a" ] || [ -z "$c" ] || [ -z "$p" ]; then
+    echo $HOWTO && exit 1;
+fi
+
+path_repo="git@github.com:IIC2233/${a}.git"
+
+mkdir $a
+
+cd $a
+
+git init
+
+git sparse-checkout init
+
+git remote add -f origin $path_repo
+
+my_students=
+
+INPUT="../$p"
+OLDIFS=$IFS
+IFS=','
+[ ! -f $INPUT ] && { echo "$INPUT file not found"; exit 99; }
+while read student_github assistant_github commit_hash
+do
+    if [ $assistant_github = $c ]; then
+        my_students="$my_students $student_github"
+    fi
+done < $INPUT
+IFS=$OLDIFS
+
+eval "git sparse-checkout set $my_students"
+git pull origin master


### PR DESCRIPTION
Usé tu script de python para descargar los repos y falló enseguida, porque mi versión de git está mas vieja. Sin embargo, esto es problemático, porque para actualizar a una nueva necesito agregar un ppa con una versión más reciente de git, y como buen programador decidí que era mejor crear un script para no hacer eso.

Entonces, lo que hice fue hacer un script .sh que funciona en versiones más viejas de git, lo que hace es exactamente lo mismo que debería hacer el otro script pero de una forma amigable con git 2.25 ( ```git clone --sparse``` no funciona bien y ```git sparse-checkout add``` no existe).

Luego me dio lata que el .py no funcionara para versiones antiguas de git y lo modifiqué también para que funcionara en ellas. Lo hice para que funcionara de la misma forma que el .sh.

Tambien hice unos cambios menores para consistencia en el .py, y cambie la url de los repos a la url ssh (que la de https me falla en mi version de linux).

Cualquier cambio que deba hacer a esto porfa avisenme y lo hago. Si todo esto esta bien, actualizo el readme tb.